### PR TITLE
Fix live share URL join and encryption modal issues

### DIFF
--- a/client/live-share.js
+++ b/client/live-share.js
@@ -132,6 +132,9 @@
   const joinKeyInput = document.getElementById('join-key-input');
   const joinConfirmBtn = document.getElementById('join-confirm-btn');
   const joinCancelBtn = document.getElementById('join-cancel-btn');
+  const joinEncryptedCheck = document.getElementById('join-encrypted-checkbox');
+  const joinEncRow = document.getElementById('join-encryption-row');
+  const joinEncInput = document.getElementById('join-encryption-key-input');
 
   let session = { key: null, hostToken: null, role: 'idle', ws: null, encrypted: false, encryptionKey: null };
   let version = 0;
@@ -580,14 +583,11 @@
   const submitJoin = () => { joinConfirmBtn?.click(); };
   joinKeyInput?.addEventListener('keydown', (e) => { if (e.key === 'Enter') { e.preventDefault(); submitJoin(); }});
   joinEncInput?.addEventListener('keydown', (e) => { if (e.key === 'Enter') { e.preventDefault(); submitJoin(); }});
-  const joinEncryptedCheck = document.getElementById('join-encrypted-checkbox');
-  const joinEncRow = document.getElementById('join-encryption-row');
   if (joinEncryptedCheck && joinEncRow) {
     joinEncryptedCheck.addEventListener('change', () => {
       joinEncRow.style.display = joinEncryptedCheck.checked ? 'block' : 'none';
     });
   }
-  const joinEncInput = document.getElementById('join-encryption-key-input');
   if (joinEncInput) {
     joinEncInput.addEventListener('input', () => {
       joinEncInput.value = joinEncInput.value.toUpperCase().replace(/[^A-Z]/g, '').slice(0, 6);
@@ -607,6 +607,8 @@
   });
 
   // Auto-join if URL has ?share=KEY (or open join modal for encrypted ?share=KEY&e=1)
+  // Encrypted links: show join modal immediately (checkbox + encryption key input)
+  // Non-encrypted: defer until editor is ready so snapshot content can be applied
   const urlParams = new URLSearchParams(location.search);
   const initialKey = urlParams.get('share');
   const isEncryptedLink = urlParams.get('e') === '1';
@@ -615,7 +617,29 @@
     if (isEncryptedLink) {
       openJoinModal({ key: normalizedInitial, encrypted: true });
     } else {
-      joinByKey(normalizedInitial);
+      const doJoin = () => {
+        joinByKey(normalizedInitial);
+      };
+      if (getEditor()) {
+        doJoin();
+      } else {
+        let attempts = 0;
+        const maxAttempts = 300; // ~5s at 60fps
+        const checkEditor = () => {
+          if (getEditor()) {
+            doJoin();
+            return;
+          }
+          if (++attempts < maxAttempts) {
+            requestAnimationFrame(checkEditor);
+          }
+        };
+        if (document.readyState === 'complete') {
+          checkEditor();
+        } else {
+          window.addEventListener('load', () => setTimeout(checkEditor, 50));
+        }
+      }
     }
   }
 })(); 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes two issues introduced by the recent encryption changes:

### 1. Direct URL join not working
- **Root cause**: `joinEncInput` was used at line 582 before being declared at line 590, causing a ReferenceError (temporal dead zone) that crashed the entire `live-share.js` script
- **Fix**: Declare `joinEncryptedCheck`, `joinEncRow`, and `joinEncInput` with other UI elements at the top of the file

### 2. Non-encrypted direct URL join showing empty content
- **Root cause**: Auto-join ran immediately on page load, before Monaco editor was initialized. The snapshot was fetched and applied before `window.editor` existed, so content was never set
- **Fix**: Defer `joinByKey` for non-encrypted links until the editor is ready (poll via `requestAnimationFrame`), with a 5s timeout fallback

### 3. Encrypted join modal not showing checkbox/key on mobile
- **Root cause**: Same script crash from #1 prevented the join modal from ever opening
- **Fix**: For encrypted links (`?share=KEY&e=1`), show the join modal immediately (no need to wait for editor). The modal shows with:
  - Encrypted checkbox checked
  - Encryption key input row visible

## Changes

- `client/live-share.js`:
  - Move `joinEncryptedCheck`, `joinEncRow`, `joinEncInput` declarations to UI elements section
  - Remove duplicate declarations
  - Add editor-ready check before auto-joining non-encrypted sessions
  - Encrypted links: open join modal immediately

## Testing

- [ ] Direct URL: `https://editor/?share=ABC-234` (non-encrypted) - should join and show content
- [ ] Direct URL: `https://editor/?share=ABC-234&e=1` (encrypted) - should show join modal with checkbox checked and encryption key input
- [ ] Manual "Join Session" from menu - should show join modal with encryption option
- [ ] Test on mobile device
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3642898d-a642-4600-afdd-c172652f733e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3642898d-a642-4600-afdd-c172652f733e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

